### PR TITLE
Homebrew has deprecated the --clean flag

### DIFF
--- a/bin/setup-new-mac
+++ b/bin/setup-new-mac
@@ -41,7 +41,7 @@ fi
 for pkg in vim bash-completion git nodenv node-build rbenv ruby-build postgresql wget tree jid jq heroku fzf ripgrep; do
   if brew list -1 | grep -q "^${pkg}\$"; then
     echo "Package '$pkg' is installed; updating:"
-    brew upgrade "$pkg" --cleanup || true
+    brew upgrade "$pkg" && brew cleanup "$pkg" || true
   else
     brew install "$pkg"
   fi


### PR DESCRIPTION
The clean flag no longer works with the upgrade command and will result in packages not being properly upgraded. Adding clean as a separate command with the appropriate package fixes this. <3